### PR TITLE
Make ShellOutCommand hashable as well

### DIFF
--- a/Sources/ShellOutCommand.swift
+++ b/Sources/ShellOutCommand.swift
@@ -1,5 +1,5 @@
 /// Structure used to pre-define commands for use with ShellOut
-public struct ShellOutCommand: Equatable {
+public struct ShellOutCommand: Equatable, Hashable {
     /// The string that makes up the command that should be run on the command line
     public var command: String
 


### PR DESCRIPTION
```
Test Suite 'All tests' started at 2023-10-09 10:24:05.286.
Test Suite 'ShellOutTests.xctest' started at 2023-10-09 10:24:05.286.
Test Suite 'ShellOutTests' started at 2023-10-09 10:24:05.286.
Test Case '-[ShellOutTests.ShellOutTests test_appendArguments]' started.
Test Case '-[ShellOutTests.ShellOutTests test_appendArguments]' passed (0.001 seconds).
Test Case '-[ShellOutTests.ShellOutTests test_appendingArguments]' started.
Test Case '-[ShellOutTests.ShellOutTests test_appendingArguments]' passed (0.000 seconds).
Test Case '-[ShellOutTests.ShellOutTests test_Argument_ExpressibleByStringLiteral]' started.
Test Case '-[ShellOutTests.ShellOutTests test_Argument_ExpressibleByStringLiteral]' passed (0.001 seconds).
Test Case '-[ShellOutTests.ShellOutTests test_Argument_url]' started.
Test Case '-[ShellOutTests.ShellOutTests test_Argument_url]' passed (0.000 seconds).
Test Case '-[ShellOutTests.ShellOutTests test_git_tags]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/test_stress_95C16462-5BB9-4F58-90CC-99ECA078B140 [ShellOut] unzip /Users/sas/Projects/SPI/ShellOut/Tests/ShellOutTests/Fixtures/ErrNo.zip
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/test_stress_95C16462-5BB9-4F58-90CC-99ECA078B140/ErrNo [ShellOut] git tag
Test Case '-[ShellOutTests.ShellOutTests test_git_tags]' passed (0.019 seconds).
Test Case '-[ShellOutTests.ShellOutTests testBashArgumentQuoting]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] bash -c 'echo '\''foo ; echo bar'\'''
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] bash -c 'echo foo ; echo bar'
Test Case '-[ShellOutTests.ShellOutTests testBashArgumentQuoting]' passed (0.006 seconds).
Test Case '-[ShellOutTests.ShellOutTests testBash]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] bash -c 'echo foo'
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] bash -c 'echo foo'
Test Case '-[ShellOutTests.ShellOutTests testBash]' passed (0.005 seconds).
Test Case '-[ShellOutTests.ShellOutTests testCapturingErrorWithHandle]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] bash -c ''\''cd notADirectory'\'''
Test Case '-[ShellOutTests.ShellOutTests testCapturingErrorWithHandle]' passed (0.005 seconds).
Test Case '-[ShellOutTests.ShellOutTests testCapturingOutputWithHandle]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] echo Hello
Test Case '-[ShellOutTests.ShellOutTests testCapturingOutputWithHandle]' passed (0.003 seconds).
Test Case '-[ShellOutTests.ShellOutTests testErrorDescription]' started.
Test Case '-[ShellOutTests.ShellOutTests testErrorDescription]' passed (0.000 seconds).
Test Case '-[ShellOutTests.ShellOutTests testGitCommands]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ [ShellOut] rm -rf GitTestOrigin
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ [ShellOut] rm -rf GitTestClone
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ [ShellOut] mkdir GitTestOrigin
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestOrigin [ShellOut] git init
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestOrigin [ShellOut] bash -c 'echo '\''Hello world'\'' > Test'
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestOrigin [ShellOut] git add .
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestOrigin [ShellOut] git commit -a -m Commit --quiet
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ [ShellOut] git clone file:///var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestOrigin/ GitTestClone --quiet
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] cat /var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestClone/Test
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestOrigin [ShellOut] bash -c 'echo '\''Hello again'\'' > Test'
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestOrigin [ShellOut] git commit -a -m Commit --quiet
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestClone [ShellOut] git pull --quiet
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] cat /var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/GitTestClone/Test
Test Case '-[ShellOutTests.ShellOutTests testGitCommands]' passed (0.144 seconds).
Test Case '-[ShellOutTests.ShellOutTests testSingleCommandAtPathContainingSpace]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ [ShellOut] mkdir -p 'ShellOut Test Folder'
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/ShellOut Test Folder [ShellOut] bash -c 'echo Hello > File'
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] cat '/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/ShellOut Test Folder/File'
Test Case '-[ShellOutTests.ShellOutTests testSingleCommandAtPathContainingSpace]' passed (0.009 seconds).
Test Case '-[ShellOutTests.ShellOutTests testSingleCommandAtPathContainingTilde]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/Users/sas [ShellOut] ls -a
Test Case '-[ShellOutTests.ShellOutTests testSingleCommandAtPathContainingTilde]' passed (0.005 seconds).
Test Case '-[ShellOutTests.ShellOutTests testSingleCommandAtPath]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] bash -c 'echo Hello > "/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ/ShellOutTests-SingleCommand.txt"'
2023-10-09T10:24:05+0200 debug test : cwd=/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/ShellOutTests.veWGIQ [ShellOut] cat ShellOutTests-SingleCommand.txt
Test Case '-[ShellOutTests.ShellOutTests testSingleCommandAtPath]' passed (0.006 seconds).
Test Case '-[ShellOutTests.ShellOutTests testThrowingError]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] bash -c ''\''cd notADirectory'\'''
Test Case '-[ShellOutTests.ShellOutTests testThrowingError]' passed (0.003 seconds).
Test Case '-[ShellOutTests.ShellOutTests testWithArguments]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] echo 'Hello world'
Test Case '-[ShellOutTests.ShellOutTests testWithArguments]' passed (0.003 seconds).
Test Case '-[ShellOutTests.ShellOutTests testWithoutArguments]' started.
2023-10-09T10:24:05+0200 debug test : cwd=/private/tmp [ShellOut] uptime
Test Case '-[ShellOutTests.ShellOutTests testWithoutArguments]' passed (0.004 seconds).
Test Suite 'ShellOutTests' passed at 2023-10-09 10:24:05.509.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.214 (0.223) seconds
Test Suite 'ShellOutTests.xctest' passed at 2023-10-09 10:24:05.510.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.214 (0.223) seconds
Test Suite 'All tests' passed at 2023-10-09 10:24:05.510.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.214 (0.224) seconds
Program ended with exit code: 0
```