### PR TITLE
Rename Argument to ShellArgument

### DIFF
--- a/Sources/ShellArgument.swift
+++ b/Sources/ShellArgument.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Argument: Equatable {
+public enum ShellArgument: Equatable {
     case quoted(QuotedString)
     case verbatim(String)
 
@@ -13,13 +13,13 @@ public enum Argument: Equatable {
     }
 }
 
-extension Argument: ExpressibleByStringLiteral {
+extension ShellArgument: ExpressibleByStringLiteral {
     public init(stringLiteral value: StringLiteralType) {
         self = .quoted(.init(value))
     }
 }
 
-extension Argument: CustomStringConvertible {
+extension ShellArgument: CustomStringConvertible {
     public var description: String {
         switch self {
             case let .quoted(value):
@@ -30,17 +30,17 @@ extension Argument: CustomStringConvertible {
     }
 }
 
-extension Argument {
+extension ShellArgument {
     public static func url(_ url: URL) -> Self { url.absoluteString.verbatim }
 }
 
 
 extension StringProtocol {
-    public var quoted: Argument { .init(quoted: self) }
-    public var verbatim: Argument { .init(verbatim: self) }
+    public var quoted: ShellArgument { .init(quoted: self) }
+    public var verbatim: ShellArgument { .init(verbatim: self) }
 }
 
 extension Sequence<StringProtocol> {
-    public var quoted: [Argument] { map(\.quoted) }
-    public var verbatim: [Argument] { map(\.verbatim) }
+    public var quoted: [ShellArgument] { map(\.quoted) }
+    public var verbatim: [ShellArgument] { map(\.verbatim) }
 }

--- a/Sources/ShellOutCommand+other.swift
+++ b/Sources/ShellOutCommand+other.swift
@@ -1,5 +1,5 @@
 public extension ShellOutCommand {
-    static func bash(arguments: [Argument]) -> Self {
+    static func bash(arguments: [ShellArgument]) -> Self {
         let arguments = arguments.first == "-c" ? Array(arguments.dropFirst()) : arguments
         return .init(command: "bash", arguments: ["-c", arguments.map(\.description).joined(separator: " ")])
     }

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -223,12 +223,12 @@ final class ShellOutTests: XCTestCase {
     }
 
     func test_Argument_ExpressibleByStringLiteral() throws {
-        XCTAssertEqual(("foo" as Argument).description, "foo")
-        XCTAssertEqual(("foo bar" as Argument).description, "'foo bar'")
+        XCTAssertEqual(("foo" as ShellArgument).description, "foo")
+        XCTAssertEqual(("foo bar" as ShellArgument).description, "'foo bar'")
     }
 
     func test_Argument_url() throws {
-        XCTAssertEqual(Argument.url(.init(string: "https://example.com")!).description,
+        XCTAssertEqual(ShellArgument.url(.init(string: "https://example.com")!).description,
                        "https://example.com")
     }
 


### PR DESCRIPTION
This change simplifies usage alongside [ArgumentParser](https://github.com/apple/swift-argument-parser).